### PR TITLE
Assign feature image as array

### DIFF
--- a/src/importers/PostType.php
+++ b/src/importers/PostType.php
@@ -128,7 +128,7 @@ class PostType extends BaseConfigurableImporter
             $fieldValues[Tags::get()->handle] = array_map(fn(int $id) => $this->command->import(Tag::SLUG, $id), $data['tags']);
         }
         if ($data['featured_media'] ?? null) {
-            $fieldValues['featuredImage'] = $this->command->import(Media::SLUG, $data['featured_media']);
+            $fieldValues['featuredImage'] = [$this->command->import(Media::SLUG, $data['featured_media'])];
         }
         if ($this->supports('comments') && $this->command->importComments) {
             $fieldValues[Comments::get()->handle] = [


### PR DESCRIPTION
Looks like this relational field is being assigned the single `int` of the imported asset, instead of an array.

[Noted in Discord](https://discord.com/channels/456442477667418113/545074396457336835/1319756979433902081)!